### PR TITLE
@FIR-433: Made changes to remove peripheral accesses.

### DIFF
--- a/boards/tsi/skyp/tsi_skyp_m85.dts
+++ b/boards/tsi/skyp/tsi_skyp_m85.dts
@@ -89,7 +89,7 @@
 		zephyr,memory-region = "SRAM1";
 	};
 
-	soc {
+	/*soc {
 		peripheral@71000000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -97,7 +97,7 @@
 
 			 #include "tsi_skyp_m85-common.dtsi"
 		};
-	};
+	};*/
 };
 
 &jtag_uart {


### PR DESCRIPTION
The G0208 SKYP branch has peripheral accesses of UART and SPI disabled Removing the peripheral block from the DTS file